### PR TITLE
fix: error when user tries to repost an appointment

### DIFF
--- a/src/Dataport.Terminfinder.BusinessLayer.Tests/AppointmentBusinessLayerTests.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer.Tests/AppointmentBusinessLayerTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Dataport.Terminfinder.BusinessLayer.Security;
-using Dataport.Terminfinder.Repository;
+﻿using Dataport.Terminfinder.BusinessLayer.Security;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
+using Dataport.Terminfinder.Repository;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/Dataport.Terminfinder.BusinessLayer.Tests/AppointmentBusinessLayerTests.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer.Tests/AppointmentBusinessLayerTests.cs
@@ -23,7 +23,7 @@ public class AppointmentBusinessLayerTests
         "$2b$10$bKHadGFqngTajUrRAozjxeS3r5Mz6.nQwOBjT.kUcBeIF7FFYVt2W";
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<AppointmentBusinessLayer>>();
@@ -646,7 +646,7 @@ public class AppointmentBusinessLayerTests
         Guid expectedParticipantId1 = new("CF1E5ABB-7D41-41AA-8DDC-0EB0319CD6B4");
         Guid expectedParticipantId2 = new("D1C2DB5B-3FD8-4D8B-9A64-0C90298897D0");
 
-        List<Participant> fakeParcipiants = new()
+        List<Participant> fakeParticipants = new()
         {
             new Participant()
             {
@@ -688,13 +688,13 @@ public class AppointmentBusinessLayerTests
         var businessLayer = new AppointmentBusinessLayer(mockAppointmentRepo.Object, mockCustomerRepo.Object,
             _bcryptWrapper, _logger);
 
-        businessLayer.SetParticipantsForeignKeys(fakeParcipiants, expectedCustomerId, expectedAppointmentId);
+        businessLayer.SetParticipantsForeignKeys(fakeParticipants, expectedCustomerId, expectedAppointmentId);
 
-        foreach (Participant participant in fakeParcipiants)
+        foreach (Participant participant in fakeParticipants)
         {
             Assert.AreEqual(expectedCustomerId, participant.CustomerId);
             Assert.AreEqual(expectedAppointmentId, participant.AppointmentId);
-            Guid expectedParcipiantId = participant.ParticipantId;
+            Guid expectedParticipantId = participant.ParticipantId;
 
             List<Voting> votings = participant.Votings.ToList();
 
@@ -704,7 +704,7 @@ public class AppointmentBusinessLayerTests
 
                 Assert.AreEqual(expectedCustomerId, voting.CustomerId);
                 Assert.AreEqual(expectedAppointmentId, voting.AppointmentId);
-                Assert.AreEqual(expectedParcipiantId, voting.ParticipantId);
+                Assert.AreEqual(expectedParticipantId, voting.ParticipantId);
             }
         }
     }

--- a/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/BcryptWrapperTests.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/BcryptWrapperTests.cs
@@ -16,7 +16,7 @@ public class BcryptWrapperTests
     private readonly string SaltForUnittests = "$2b$10$bKHadGFqngTajUrRAozjxe";
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         logger = Mock.Of<ILogger<BcryptWrapper>>();

--- a/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/BcryptWrapperTests.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/BcryptWrapperTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Dataport.Terminfinder.BusinessLayer.Security;
+﻿using Dataport.Terminfinder.BusinessLayer.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/SaltGeneratorTests.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer.Tests/Security/SaltGeneratorTests.cs
@@ -13,7 +13,7 @@ public class SaltGeneratorTests
     private ILogger<SaltGenerator> logger;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         logger = Mock.Of<ILogger<SaltGenerator>>();

--- a/src/Dataport.Terminfinder.BusinessLayer/AppointmentBusinessLayer.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer/AppointmentBusinessLayer.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Dataport.Terminfinder.BusinessLayer.Security;
-using Dataport.Terminfinder.Repository;
+﻿using Dataport.Terminfinder.BusinessLayer.Security;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.Common.Extension;
+using Dataport.Terminfinder.Repository;
 
 namespace Dataport.Terminfinder.BusinessLayer;
 

--- a/src/Dataport.Terminfinder.BusinessLayer/IAppointmentBusinessLayer.cs
+++ b/src/Dataport.Terminfinder.BusinessLayer/IAppointmentBusinessLayer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessObject;
+﻿using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 
 namespace Dataport.Terminfinder.BusinessLayer;

--- a/src/Dataport.Terminfinder.BusinessObject/Appointment.cs
+++ b/src/Dataport.Terminfinder.BusinessObject/Appointment.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessObject.Enum;
+﻿using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.JsonSerializer;
 using Dataport.Terminfinder.BusinessObject.Validators;
 using Dataport.Terminfinder.Common.Extension;

--- a/src/Dataport.Terminfinder.BusinessObject/Participant.cs
+++ b/src/Dataport.Terminfinder.BusinessObject/Participant.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessObject.JsonSerializer;
+﻿using Dataport.Terminfinder.BusinessObject.JsonSerializer;
 
 namespace Dataport.Terminfinder.BusinessObject;
 

--- a/src/Dataport.Terminfinder.BusinessObject/SuggestedDate.cs
+++ b/src/Dataport.Terminfinder.BusinessObject/SuggestedDate.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessObject.JsonSerializer;
+﻿using Dataport.Terminfinder.BusinessObject.JsonSerializer;
 using Dataport.Terminfinder.BusinessObject.Validators;
 using JetBrains.Annotations;
 

--- a/src/Dataport.Terminfinder.Common.Tests/Extension/EnumerableExtensionsTests.cs
+++ b/src/Dataport.Terminfinder.Common.Tests/Extension/EnumerableExtensionsTests.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Dataport.Terminfinder.Common.Extension;
+﻿using Dataport.Terminfinder.Common.Extension;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Dataport.Terminfinder.Common.Tests.Extension;

--- a/src/Dataport.Terminfinder.Common/Extension/EnumerableExtensions.cs
+++ b/src/Dataport.Terminfinder.Common/Extension/EnumerableExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace Dataport.Terminfinder.Common.Extension;
+﻿namespace Dataport.Terminfinder.Common.Extension;
 
 /// <summary>
 /// Extension methods for interface IEnumerable

--- a/src/Dataport.Terminfinder.DeleteAppointments.Tool.Tests/DeleteAppointmentsTests.cs
+++ b/src/Dataport.Terminfinder.DeleteAppointments.Tool.Tests/DeleteAppointmentsTests.cs
@@ -15,7 +15,7 @@ public class DeleteAppointmentsTests
     private IDateTimeGeneratorService _dateTimeGeneratorServiceFake;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<DeleteAppointmentsService>>();

--- a/src/Dataport.Terminfinder.DeleteAppointments.Tool.Tests/DeleteAppointmentsTests.cs
+++ b/src/Dataport.Terminfinder.DeleteAppointments.Tool.Tests/DeleteAppointmentsTests.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dataport.Terminfinder.Console.DeleteAppointments.Tool.Tests;
 

--- a/src/Dataport.Terminfinder.DeleteAppointments.Tool/DeleteAppointmentsService.cs
+++ b/src/Dataport.Terminfinder.DeleteAppointments.Tool/DeleteAppointmentsService.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Dataport.Terminfinder.Console.DeleteAppointments.Tool;
+﻿namespace Dataport.Terminfinder.Console.DeleteAppointments.Tool;
 
 /// <summary>
 /// delete all appointments, if the oldest startdate (when enddate is null) or the oldest enddate older than x days

--- a/src/Dataport.Terminfinder.DeleteAppointments.Tool/IRepository.cs
+++ b/src/Dataport.Terminfinder.DeleteAppointments.Tool/IRepository.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace Dataport.Terminfinder.Console.DeleteAppointments.Tool;
 

--- a/src/Dataport.Terminfinder.DeleteAppointments.Tool/Repository.cs
+++ b/src/Dataport.Terminfinder.DeleteAppointments.Tool/Repository.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Data;
-using Npgsql;
+﻿using Npgsql;
 using NpgsqlTypes;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dataport.Terminfinder.Console.DeleteAppointments.Tool;
 
 /// <inheritdoc cref="IRepository" />
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[ExcludeFromCodeCoverage]
 public class Repository : IRepository
 {
     private readonly ILogger _logger;

--- a/src/Dataport.Terminfinder.Repository.Tests/AppConfigRepositoryTests.cs
+++ b/src/Dataport.Terminfinder.Repository.Tests/AppConfigRepositoryTests.cs
@@ -7,7 +7,7 @@ public class AppConfigRepositoryTests
     private ILogger<AppConfigRepository> _logger;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<AppConfigRepository>>();

--- a/src/Dataport.Terminfinder.Repository.Tests/AppointmentRepositoryTests.cs
+++ b/src/Dataport.Terminfinder.Repository.Tests/AppointmentRepositoryTests.cs
@@ -7,7 +7,7 @@ public class AppointmentRepositoryTests
     private ILogger<AppointmentRepository> _logger;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<AppointmentRepository>>();

--- a/src/Dataport.Terminfinder.Repository.Tests/CustomerRepositoryTests.cs
+++ b/src/Dataport.Terminfinder.Repository.Tests/CustomerRepositoryTests.cs
@@ -7,7 +7,7 @@ public class CustomerRepositoryTests
     private ILogger<CustomerRepository> _logger;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<CustomerRepository>>();

--- a/src/Dataport.Terminfinder.Repository/AppointmentRepository.cs
+++ b/src/Dataport.Terminfinder.Repository/AppointmentRepository.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
-using Dataport.Terminfinder.BusinessObject;
+﻿using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.Common.Extension;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Dataport.Terminfinder.Repository.Tests")]
 

--- a/src/Dataport.Terminfinder.Repository/IAppointmentRepository.cs
+++ b/src/Dataport.Terminfinder.Repository/IAppointmentRepository.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessObject;
+﻿using Dataport.Terminfinder.BusinessObject;
 
 namespace Dataport.Terminfinder.Repository;
 

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AdminControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AdminControllerTests.cs
@@ -9,7 +9,7 @@ public class AdminControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<AdminController>>();
@@ -26,7 +26,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_Okay()
+    public void GetAppointment_Okay()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedAdminId = new ("0EB748E2-32CF-49DE-8A63-14685AC943FF");
@@ -72,7 +72,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_AdminIdIsEmpty()
+    public void GetAppointment_AdminIdIsEmpty()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedAdminId = new ("0EB748E2-32CF-49DE-8A63-14685AC943FF");
@@ -116,7 +116,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_NotFound()
+    public void GetAppointment_NotFound()
     {
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
 
@@ -142,7 +142,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_verificationFailed_Unauthorized()
+    public void GetAppointment_verificationFailed_Unauthorized()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -196,7 +196,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_verificationSuccessful_okay()
+    public void GetAppointment_verificationSuccessful_okay()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -394,7 +394,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_verificationSuccessful_True()
+    public void GetPasswordVerification_verificationSuccessful_True()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -437,7 +437,7 @@ public class AdminControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAdminId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAdminId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;
@@ -448,7 +448,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_verificationSuccessful_False()
+    public void GetPasswordVerification_verificationSuccessful_False()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -491,7 +491,7 @@ public class AdminControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAdminId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAdminId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;
@@ -502,7 +502,7 @@ public class AdminControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_AppointmentNotProtected_True()
+    public void GetPasswordVerification_AppointmentNotProtected_True()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -545,7 +545,7 @@ public class AdminControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAdminId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAdminId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppControllerTests.cs
@@ -9,7 +9,7 @@ public class AppControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<AppController>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppointmentControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppointmentControllerTests.cs
@@ -9,7 +9,7 @@ public class AppointmentControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         _logger = Mock.Of<ILogger<AppointmentController>>();
@@ -22,7 +22,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_Okay()
+    public void GetAppointment_Okay()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
@@ -67,7 +67,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_AppointmentId_NotFound()
+    public void GetAppointment_AppointmentId_NotFound()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
@@ -95,7 +95,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_AppointmentIdIsEmpty()
+    public void GetAppointment_AppointmentIdIsEmpty()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
@@ -145,7 +145,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_noUserCredentialSubmittedButTheyAreRequired_Unauthorized()
+    public void GetAppointment_noUserCredentialSubmittedButTheyAreRequired_Unauthorized()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
@@ -189,7 +189,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_verificationFailed_Unauthorized()
+    public void GetAppointment_verificationFailed_Unauthorized()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -244,7 +244,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_verificationFailedPasswordCanNotBeDecoded_BadRequest()
+    public void GetAppointment_verificationFailedPasswordCanNotBeDecoded_BadRequest()
     {
         Guid expectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
@@ -292,7 +292,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetApppointment_verificationSuccessful_okay()
+    public void GetAppointment_verificationSuccessful_okay()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -344,7 +344,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void AddApppointment_Okay()
+    public void AddAppointment_Okay()
     {
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
         Guid expectedAdminId = new ("8FD9B537-2BF4-4931-A86B-F805715BAF8C");
@@ -487,7 +487,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void AddApppointment_WithAppointmentId_FailtNotFound()
+    public void AddAppointment_WithAppointmentId_FailedNotFound()
     {
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
         Guid appointmentId = new ("3C1178B4-7115-46DA-AABA-F388ADAEF76E");
@@ -543,7 +543,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void AddApppointment_WithAdminId_FailtNotFound()
+    public void AddAppointment_WithAdminId_FailedNotFound()
     {
         Guid expectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
         Guid adminId = new ("3C1178B4-7115-46DA-AABA-F388ADAEF76E");
@@ -599,7 +599,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void AddApppointment_verificationFailed_Unauthorized()
+    public void AddAppointment_verificationFailed_Unauthorized()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -751,7 +751,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_verificationSuccessful_True()
+    public void GetPasswordVerification_verificationSuccessful_True()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -793,7 +793,7 @@ public class AppointmentControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;
@@ -804,7 +804,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_verificationSuccessful_False()
+    public void GetPasswordVerification_verificationSuccessful_False()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -846,7 +846,7 @@ public class AppointmentControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;
@@ -857,7 +857,7 @@ public class AppointmentControllerTests
     }
 
     [TestMethod]
-    public void GetPasswordVerifcation_AppointmentNotProtected_True()
+    public void GetPasswordVerification_AppointmentNotProtected_True()
     {
         const string expectedPassword = "P@$$w0rd";
 
@@ -899,7 +899,7 @@ public class AppointmentControllerTests
 
         // Act
         IActionResult httpResult =
-            controller.GetPasswordVerifcation(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
+            controller.GetPasswordVerification(expectedCustomerId.ToString(), expectedAppointmentId.ToString());
         OkObjectResult result = httpResult as OkObjectResult;
         AppointmentPasswordVerificationResult verificationResult =
             result?.Value as AppointmentPasswordVerificationResult;

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppointmentControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/AppointmentControllerTests.cs
@@ -7,11 +7,12 @@ public class AppointmentControllerTests
     private ILogger<AppointmentController> _logger;
     private IStringLocalizer<AppointmentController> _localizer;
     private IRequestContext _requestContext;
-    
-    private static readonly Guid ExpectedAppointmentId = new ("C1C2474B-488A-4ECF-94E8-47387BB715D5");
-    private static readonly Guid ExpectedCustomerId = new ("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
-    private static readonly Guid ExpectedAdminId = new ("FFFD657A-4D06-40DB-8443-D67BBB950EE7");
+
+    private static readonly Guid ExpectedAppointmentId = new("C1C2474B-488A-4ECF-94E8-47387BB715D5");
+    private static readonly Guid ExpectedCustomerId = new("BE1D657A-4D06-40DB-8443-D67BBB950EE7");
+    private static readonly Guid ExpectedAdminId = new("FFFD657A-4D06-40DB-8443-D67BBB950EE7");
     private const string ExpectedPassword = "P@$$w0rd";
+
     private static readonly Appointment FakeAppointment = new()
     {
         AppointmentId = ExpectedAppointmentId,
@@ -261,7 +262,7 @@ public class AppointmentControllerTests
     [TestMethod]
     public void AddAppointment_Okay()
     {
-        Guid expectedSuggestedDateId1 = new ("5FE9C00C-A59C-4985-A2BB-53D179C2B52C");
+        Guid expectedSuggestedDateId1 = new("5FE9C00C-A59C-4985-A2BB-53D179C2B52C");
 
         Appointment fakeAppointment = new()
         {
@@ -321,11 +322,11 @@ public class AppointmentControllerTests
             EndDate = new DateTime(2018, 12, 12).AddDays(1)
         };
 
-        SuggestedDate fakeSuggestedDateReturn2 = new ()
+        SuggestedDate fakeSuggestedDateReturn2 = new()
         {
             AppointmentId = fakeAppointmentReturn.AppointmentId,
             CustomerId = ExpectedCustomerId,
-            SuggestedDateId = new ("76AAC930-EC94-4B78-8F5B-B108E1A53860"),
+            SuggestedDateId = new("76AAC930-EC94-4B78-8F5B-B108E1A53860"),
             StartDate = new DateTime(2018, 12, 14),
             StartTime = new DateTimeOffset(2018, 12, 14, 20, 05, 0, new TimeSpan(1, 0, 0)),
             EndDate = new DateTime(2018, 12, 14),

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/CustomerControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/CustomerControllerTests.cs
@@ -9,7 +9,7 @@ public class CustomerControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<CustomerController>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/ParticipantControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/ParticipantControllerTests.cs
@@ -9,7 +9,7 @@ public class ParticipantControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<ParticipantController>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/SuggestedDateControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/SuggestedDateControllerTests.cs
@@ -9,7 +9,7 @@ public class SuggestedDateControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         var mockLog = new Mock<ILogger<SuggestedDateController>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/VotingControllerTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Controllers/VotingControllerTests.cs
@@ -9,7 +9,7 @@ public class VotingControllerTests
     private IRequestContext _requestContext;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake logger
         _logger = Mock.Of<ILogger<VotingController>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AdminControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AdminControllerIntegrationTests.cs
@@ -12,7 +12,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     private Guid _customerId = new("E1E81104-3944-4588-A48E-B64BDE473E1A");
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);
@@ -20,7 +20,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment()
+    public async Task GetAppointment()
     {
         HttpClient client = _testServer.CreateClient();
         var dto = await CreateTestAppointmentInDatabase(client, _customerId);
@@ -55,7 +55,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_AdminIdIsEmpty()
+    public async Task GetAppointment_AdminIdIsEmpty()
     {
         HttpClient client = _testServer.CreateClient();
         await CreateTestAppointmentInDatabase(client, _customerId);
@@ -72,7 +72,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_NotFound()
+    public async Task GetAppointment_NotFound()
     {
         HttpClient client = _testServer.CreateClient();
         await CreateTestAppointmentInDatabase(client, _customerId);
@@ -89,7 +89,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_verificationFailed_Unauthorized()
+    public async Task GetAppointment_verificationFailed_Unauthorized()
     {
         var password = "P@$$w0rd";
 
@@ -121,7 +121,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_verificationSuccessful_okay()
+    public async Task GetAppointment_verificationSuccessful_okay()
     {
         var password = "P@$$w0rd";
 
@@ -193,7 +193,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetPasswordVerifcation_verificationSuccessful_True()
+    public async Task GetPasswordVerification_verificationSuccessful_True()
     {
         var password = "P@$$w0rd";
 
@@ -219,7 +219,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetPasswordVerifcation_verificationSuccessful_False()
+    public async Task GetPasswordVerification_verificationSuccessful_False()
     {
         var password = "P@$$w0rd";
 
@@ -245,7 +245,7 @@ public class AdminControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetPasswordVerifcation_AppointmentNotProtected_True()
+    public async Task GetPasswordVerification_AppointmentNotProtected_True()
     {
         var password = "P@$$w0rd";
 

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppControllerIntegrationTests.cs
@@ -8,7 +8,7 @@ public class AppControllerIntegrationTests : BaseIntegrationTests
     private TestServer _testServer;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppointmentControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppointmentControllerIntegrationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Dataport.Terminfinder.WebAPI.Constants;
-using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppointmentControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/AppointmentControllerIntegrationTests.cs
@@ -14,7 +14,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     private Guid _customerId = new("E1E81104-3944-4588-A48E-B64BDE473E1A");
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);
@@ -22,7 +22,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task AddApppointment()
+    public async Task AddAppointment()
     {
         var appointment = CreateTestAppointment(_customerId, Guid.Empty);
 
@@ -101,7 +101,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
         Assert.AreEqual(appointmentId, protectionResult.AppointmentId);
         Assert.AreEqual(false, protectionResult.IsProtectedByPassword);
 
-        //-- get GetPasswordVerifcation
+        //-- get GetPasswordVerification
         // Act
         response = await client.GetAsync($"appointment/{_customerId}/{appointmentId}/passwordverification");
 
@@ -118,7 +118,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task UpdateApppointment()
+    public async Task UpdateAppointment()
     {
         var appointment = CreateTestAppointment(_customerId, Guid.Empty);
 
@@ -247,7 +247,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_AppointmentId_NotFound()
+    public async Task GetAppointment_AppointmentId_NotFound()
     {
         Guid appointmentId = new("C1C2474B-488A-4ECF-94E8-47387BB715D5");
 
@@ -262,7 +262,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_AppointmentId_InvalidGuid()
+    public async Task GetAppointment_AppointmentId_InvalidGuid()
     {
         var appointmentId = "C1C2474B-488A-4ECF-94E8-47387BB715D6";
 
@@ -277,7 +277,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetApppointment_AppointmentId_InvalidCustomerId()
+    public async Task GetAppointment_AppointmentId_InvalidCustomerId()
     {
         var appointmentId = "C1C2474B-488A-4ECF-94E8-47387BB715D5";
 
@@ -292,7 +292,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task AddApppointment_WithAdminId_BadRequest()
+    public async Task AddAppointment_WithAdminId_BadRequest()
     {
         Guid adminId = new("FFFD657A-4D06-40DB-8443-D67BBB950EE7");
 
@@ -312,7 +312,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task AddApppointment_WithPassword_Unauthorized()
+    public async Task AddAppointment_WithPassword_Unauthorized()
     {
         var appointment = CreateTestAppointment(_customerId, Guid.Empty, "P@$$w0rd");
 
@@ -344,7 +344,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task AddApppointment_WithWrongPassword_BadRequest()
+    public async Task AddAppointment_WithWrongPassword_BadRequest()
     {
         //--- too short
         var password = "12345";
@@ -385,7 +385,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task AddApppointment_WithPassword()
+    public async Task AddAppointment_WithPassword()
     {
         var password = "P@$$w0rd";
 
@@ -483,7 +483,7 @@ public class AppointmentControllerIntegrationTests : BaseIntegrationTests
     }
 
     [TestMethod]
-    public async Task GetPasswordVerifcation()
+    public async Task GetPasswordVerification()
     {
         var password = "P@$$w0rd";
 

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/BaseIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/BaseIntegrationTests.cs
@@ -1,6 +1,4 @@
 ﻿using Dataport.Terminfinder.WebAPI.Constants;
-using Microsoft.Extensions.Configuration;
-using System.IO;
 using System.Text;
 
 namespace Dataport.Terminfinder.WebAPI.Tests.IntegrationTests;

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/CustomerControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/CustomerControllerIntegrationTests.cs
@@ -9,7 +9,7 @@ public class CustomerControllerIntegrationTests : BaseIntegrationTests
     private Guid _customerId = new("E1E81104-3944-4588-A48E-B64BDE473E1A");
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/ParticipantControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/ParticipantControllerIntegrationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Dataport.Terminfinder.WebAPI.Constants;
-using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/ParticipantControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/ParticipantControllerIntegrationTests.cs
@@ -14,7 +14,7 @@ public class ParticipantControllerIntegrationTests : BaseIntegrationTests
     private Guid _customerId = new("E1E81104-3944-4588-A48E-B64BDE473E1A");
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/VotingControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/VotingControllerIntegrationTests.cs
@@ -13,7 +13,7 @@ public class VotingControllerIntegrationTests : BaseIntegrationTests
     private Guid _customerId = new("E1E81104-3944-4588-A48E-B64BDE473E1A");
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         var config = GetConfigurationBuilder();
         var builder = new WebHostBuilder().UseStartup<Startup>().UseConfiguration(config);

--- a/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/VotingControllerIntegrationTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/IntegrationTests/VotingControllerIntegrationTests.cs
@@ -1,5 +1,4 @@
 ﻿using Dataport.Terminfinder.WebAPI.Constants;
-using System.Linq;
 using System.Text;
 
 namespace Dataport.Terminfinder.WebAPI.Tests.IntegrationTests;

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Localisation/CustomValidationAttributeAdapterProviderTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Localisation/CustomValidationAttributeAdapterProviderTests.cs
@@ -13,7 +13,7 @@ public class CustomValidationAttributeAdapterProviderTests
     private IStringLocalizer localizer;
 
     [TestInitialize]
-    public void Inilialize()
+    public void Initialize()
     {
         // fake localizer
         var mockLocalize = new Mock<IStringLocalizer<CustomValidationAttributeAdapterProvider>>();

--- a/src/Dataport.Terminfinder.WebAPI.Tests/Localisation/CustomValidationAttributeAdapterProviderTests.cs
+++ b/src/Dataport.Terminfinder.WebAPI.Tests/Localisation/CustomValidationAttributeAdapterProviderTests.cs
@@ -1,8 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Mvc.DataAnnotations;
-using Dataport.Terminfinder.BusinessObject.Validators;
+﻿using Dataport.Terminfinder.BusinessObject.Validators;
 using Dataport.Terminfinder.WebAPI.Localisation;
 using Dataport.Terminfinder.WebAPI.Localisation.AttributeAdapters;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Dataport.Terminfinder.WebAPI.Tests.Localisation;
 

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/AdminController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/AdminController.cs
@@ -141,10 +141,10 @@ public class AdminController : ApiControllerBase
     [ProducesResponseType(typeof(IErrorResult), 404)]
     [ProducesResponseType(typeof(IErrorResult), 500)]
     [BasicAuthenticationOperation]
-    public IActionResult GetPasswordVerifcation(string customerId, string adminId)
+    public IActionResult GetPasswordVerification(string customerId, string adminId)
     {
-        Logger.LogDebug("Enter {NameofGetPasswordVerifcation}, Parameter: {CustomerId}, {AdminId}",
-            nameof(GetPasswordVerifcation), customerId, adminId);
+        Logger.LogDebug("Enter {NameofGetPasswordVerification}, Parameter: {CustomerId}, {AdminId}",
+            nameof(GetPasswordVerification), customerId, adminId);
 
         if (!Guid.TryParse(customerId, out Guid customerIdGuid)
             || !Guid.TryParse(adminId, out Guid adminIdGuid))

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/ApiControllerBase.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/ApiControllerBase.cs
@@ -32,7 +32,7 @@ public abstract class ApiControllerBase : ControllerBase
     private IRequestContext RequestContext { get; }
 
     /// <summary>
-    /// Defaul constructor
+    /// Default constructor
     /// </summary>
     /// <param name="requestContext"></param>
     /// <param name="logger"></param>
@@ -238,7 +238,7 @@ public abstract class ApiControllerBase : ControllerBase
     /// <param name="customerIdFromRequest"></param>
     /// <param name="appointmentId"></param>
     /// <param name="appointmentBusinessLayer">appointment business layer</param>
-    protected void ValidateAppointmentRequestSkipPasswordVerifcation(Guid customerIdFromRequest, Guid appointmentId,
+    protected void ValidateAppointmentRequestSkipPasswordVerification(Guid customerIdFromRequest, Guid appointmentId,
         IAppointmentBusinessLayer appointmentBusinessLayer)
     {
         ValidateAppointmentRequestHelper(customerIdFromRequest, appointmentId, appointmentBusinessLayer);

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/ApiControllerBase.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/ApiControllerBase.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc;
-using Dataport.Terminfinder.BusinessLayer;
+﻿using Dataport.Terminfinder.BusinessLayer;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.Common.Extension;
 using Dataport.Terminfinder.WebAPI.Exceptions;
 using Dataport.Terminfinder.WebAPI.RequestContext;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dataport.Terminfinder.WebAPI.Controllers;
 

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/AppController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/AppController.cs
@@ -1,11 +1,10 @@
-﻿using System.Threading;
-using Microsoft.AspNetCore.Mvc;
-using Dataport.Terminfinder.BusinessLayer;
+﻿using Dataport.Terminfinder.BusinessLayer;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.Error;
 using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.WebAPI.RequestContext;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dataport.Terminfinder.WebAPI.Controllers;
 

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/AppointmentController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/AppointmentController.cs
@@ -117,7 +117,7 @@ public class AppointmentController : ApiControllerBase
             throw CreateBadRequestException(ErrorType.WrongInputOrNotAllowed);
         }
 
-        ValidateAppointmentRequestSkipPasswordVerifcation(customerIdGuid, appointmentIdGuid,
+        ValidateAppointmentRequestSkipPasswordVerification(customerIdGuid, appointmentIdGuid,
             _appointmentBusinessLayer);
 
         var result = new AppointmentProtectionResult
@@ -151,10 +151,10 @@ public class AppointmentController : ApiControllerBase
     [ProducesResponseType(typeof(IErrorResult), 404)]
     [ProducesResponseType(typeof(IErrorResult), 500)]
     [BasicAuthenticationOperation]
-    public IActionResult GetPasswordVerifcation(string customerId, string appointmentId)
+    public IActionResult GetPasswordVerification(string customerId, string appointmentId)
     {
-        Logger.LogDebug("Enter {NameofGetPasswordVerifcation}, Parameter: {CustomerId}, {AppointmentId}",
-            nameof(GetPasswordVerifcation), customerId, appointmentId);
+        Logger.LogDebug("Enter {NameofGetPasswordVerification}, Parameter: {CustomerId}, {AppointmentId}",
+            nameof(GetPasswordVerification), customerId, appointmentId);
 
         if (!Guid.TryParse(customerId, out Guid customerIdGuid))
         {
@@ -166,7 +166,7 @@ public class AppointmentController : ApiControllerBase
             throw CreateBadRequestException(ErrorType.WrongInputOrNotAllowed);
         }
 
-        ValidateAppointmentRequestSkipPasswordVerifcation(customerIdGuid, appointmentIdGuid,
+        ValidateAppointmentRequestSkipPasswordVerification(customerIdGuid, appointmentIdGuid,
             _appointmentBusinessLayer);
 
         var result = new AppointmentPasswordVerificationResult

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/AppointmentController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/AppointmentController.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.AspNetCore.Mvc;
-using Dataport.Terminfinder.BusinessLayer;
+﻿using Dataport.Terminfinder.BusinessLayer;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.Error;
 using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.WebAPI.RequestContext;
 using Dataport.Terminfinder.WebAPI.Swagger;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/CustomerController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/CustomerController.cs
@@ -1,11 +1,10 @@
-﻿using System.Threading;
-using Microsoft.AspNetCore.Mvc;
-using Dataport.Terminfinder.BusinessLayer;
+﻿using Dataport.Terminfinder.BusinessLayer;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.Error;
 using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.WebAPI.RequestContext;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dataport.Terminfinder.WebAPI.Controllers;
 

--- a/src/Dataport.Terminfinder.WebAPI/Controllers/VotingController.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Controllers/VotingController.cs
@@ -1,14 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Http.Extensions;
-using System.Collections.Generic;
-using Dataport.Terminfinder.BusinessLayer;
+﻿using Dataport.Terminfinder.BusinessLayer;
 using Dataport.Terminfinder.BusinessObject;
 using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.Error;
-using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.Common.Extension;
+using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.WebAPI.RequestContext;
 using Dataport.Terminfinder.WebAPI.Swagger;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dataport.Terminfinder.WebAPI.Controllers;
 

--- a/src/Dataport.Terminfinder.WebAPI/ErrorHandling/ErrorHandlingMiddleware.cs
+++ b/src/Dataport.Terminfinder.WebAPI/ErrorHandling/ErrorHandlingMiddleware.cs
@@ -1,10 +1,8 @@
-﻿using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using Dataport.Terminfinder.BusinessObject.Enum;
+﻿using Dataport.Terminfinder.BusinessObject.Enum;
 using Dataport.Terminfinder.BusinessObject.Error;
 using Dataport.Terminfinder.WebAPI.Constants;
 using Dataport.Terminfinder.WebAPI.Exceptions;
+using System.Net;
 
 namespace Dataport.Terminfinder.WebAPI.ErrorHandling;
 

--- a/src/Dataport.Terminfinder.WebAPI/RequestContext/RequestContextAdapter.cs
+++ b/src/Dataport.Terminfinder.WebAPI/RequestContext/RequestContextAdapter.cs
@@ -8,7 +8,7 @@ public sealed class RequestContextAdapter : IRequestContext
     [NotNull] private readonly IHttpContextAccessor _accessor;
 
     /// <summary>
-    /// Defaul constructor
+    /// Default constructor
     /// </summary>
     /// <param name="accessor"></param>
     public RequestContextAdapter(IHttpContextAccessor accessor)

--- a/src/Dataport.Terminfinder.WebAPI/Swagger/EnumTypesSchemaFilter.cs
+++ b/src/Dataport.Terminfinder.WebAPI/Swagger/EnumTypesSchemaFilter.cs
@@ -1,10 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Text;
-using System.Xml.Linq;
-using Microsoft.OpenApi.Any;
+﻿using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Xml.Linq;
 
 namespace Dataport.Terminfinder.WebAPI.Swagger;
 


### PR DESCRIPTION
When a user creates an appointment, navigates back in their browser and clicks on 'start poll' again, an error is returned because the payload now contains the previously assigned Ids. As user I would expect to land on the same success screen.
It would be possible to process the new payload but to prevent malicious intent no changes are made.

- additionally I cleaned up files I encountered